### PR TITLE
Added more accurate .gitignore regex patterns.

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,7 +74,20 @@ define(function (require, exports, module) {
       return gitIgnoreLine.slice(0, 1) !== gitIgnoreCommentChar && withoutWhitespace.length > 0;
     };
 
-    ignoreLines = gitIgnore.split(newLineRegex);
+    ignoreLines = gitIgnore.split(newLineRegex).map(
+			function (v)
+			{
+				/**
+				 * Remove preceding slash so patterns match the relative paths being provided in setFileSystemIndexFilter().
+				 * Escape "." characters to match GIT Ignore syntax.
+				 * Replace "*" with a pattern check for any characters other than directory separators.
+				 * Wrap pattern in begin-/end-string characters or directory separators.
+				 */
+				v = v.replace(/^\//g, '').replace(/\./g, '\\.').replace(/\*/g, '[^\\/\\\\]*');
+				
+				return '(^|[\\\/])' + v + '($|[\\\/])';
+			}
+		);
 
     return ignoreLines.filter(noCommentsAndWhitespaceLinesFilter);
   }


### PR DESCRIPTION
- Removed preceding slashes so patterns match the relative paths being provided in setFileSystemIndexFilter().
- Made "." characters static, and "*" dynamic for characters other than directory separators.
- Wrapping the regex in begin-/end-string characters or directory separators.
